### PR TITLE
Added cycleName attribute to set.

### DIFF
--- a/o8g/Sets/A Study in Static/set.xml
+++ b/o8g/Sets/A Study in Static/set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<set xmlns:noNamespaceSchemaLocation="CardSet.xsd" name="A Study in Static" id="457db4e2-86b4-4621-8149-4e72bf27db1d" gameId="0f38e453-26df-4c04-9d67-6d43de939c77" gameVersion="3.0.0.0" version="3.0.0.0">
+<set xmlns:noNamespaceSchemaLocation="CardSet.xsd" name="A Study in Static" cycleName="Genesis" id="457db4e2-86b4-4621-8149-4e72bf27db1d" gameId="0f38e453-26df-4c04-9d67-6d43de939c77" gameVersion="3.0.0.0" version="3.0.0.0">
 <cards>
    <card id="bc0f047c-01b1-427f-a439-d451eda02061" name="Disrupter">
 		<property name="Subtitle" value="" />


### PR DESCRIPTION
Adding the attribute should have no impact on OCTGN, but allows to know which cycle the set is a part of.
OCTGN data files are used as source material by other softwares (such as the deckbuilder I maintain), and this would be a welcomed addition that could also be used by OCTGN.

--- As a side node, I tried to use GitHub for Windows to create a branch but I apparently don't have the rights to do so. I can through the website but I'm limited to 1 file per patch-X branch (unless there's something I've done wrong).
Anyway, if this commit is validated, I'll update the other sets as well (or we can discuss a better place to put the cycle name).
