### PR TITLE
Patch for Issue 330.

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -976,10 +976,11 @@ def findDMGProtection(DMGdone, DMGtype, targetPL): # Find out if the player has 
                protectionFound += 1
                DMGdone -= 1
                card.markers[mdict['protectionAllDMG']] -= 1
-         if re.search(r'trashCost',CardsAS.get(card.model,'')):
-            if not re.search(r'trashCost-ifEmpty',CardsAS.get(card.model,'')) or (re.search(r'trashCost-ifEmpty',CardsAS.get(card.model,'')) and card.markers[mdict['protectionAllDMG']] == 0):
-               debugNotify("{} has with trashCost".format(card), 3)
-               ModifyStatus('TrashMyself', targetPL.name, card, notification = 'Quick') # If the modulator -trashCost is there, the card trashes itself in order to use it's damage prevention ability
+         for autoS in CardsAS.get(card.model,'').split('||'):
+            if re.search(r'trashCost', autoS) and re.search(re.escape(protectionType), autoS):
+               if not (re.search(r'trashCost-ifEmpty', autoS) and card.markers[mdict[protectionType]] > 0):
+                  debugNotify("{} has with trashCost".format(card), 3)
+                  ModifyStatus('TrashMyself', targetPL.name, card, notification = 'Quick') # If the modulator -trashCost is there, the card trashes itself in order to use it's damage prevention ability
          if DMGdone == 0: break
    for card in cardList:
       if card.markers[mdict[protectionType]]:
@@ -992,9 +993,10 @@ def findDMGProtection(DMGdone, DMGtype, targetPL): # Find out if the player has 
                protectionFound += 1 # We increase the protection found by 1
                DMGdone -= 1 # We reduce how much damage we still need to prevent by 1
                card.markers[mdict[protectionType]] -= 1 # We reduce the card's damage protection counters by 1
-         if re.search(r'trashCost',CardsAS.get(card.model,'')): 
-            if not re.search(r'trashCost-ifEmpty',CardsAS.get(card.model,'')) or (re.search(r'trashCost-ifEmpty',CardsAS.get(card.model,'')) and card.markers[mdict[protectionType]] == 0):
-               ModifyStatus('TrashMyself', targetPL.name, card, notification = 'Quick') # If the modulator -trashCost is there, the card trashes itself in order to use it's damage prevention ability
+         for autoS in CardsAS.get(card.model,'').split('||'):
+            if re.search(r'trashCost', autoS) and re.search(re.escape(protectionType), autoS):
+               if not (re.search(r'trashCost-ifEmpty', autoS) and card.markers[mdict[protectionType]] > 0):
+                  ModifyStatus('TrashMyself', targetPL.name, card, notification = 'Quick') # If the modulator -trashCost is there, the card trashes itself in order to use it's damage prevention ability
          if DMGdone == 0: break # If we've found enough protection to alleviate all damage, stop the search.
    if DMGtype == 'Net' or DMGtype == 'Brain': altprotectionType = 'protectionNetBrainDMG' # To check for the combined Net & Brain protection counter as well.
    else: altprotectionType = None
@@ -1009,9 +1011,11 @@ def findDMGProtection(DMGdone, DMGtype, targetPL): # Find out if the player has 
                protectionFound += 1 #
                DMGdone -= 1
                card.markers[mdict[altprotectionType]] -= 1
-         if re.search(r'trashCost',CardsAS.get(card.model,'')): 
-            if not re.search(r'trashCost-ifEmpty',CardsAS.get(card.model,'')) or (re.search(r'trashCost-ifEmpty',CardsAS.get(card.model,'')) and card.markers[mdict[altprotectionType]] == 0):
-               ModifyStatus('TrashMyself', targetPL.name, card, notification = 'Quick') # If the modulator -trashCost is there, the card trashes itself in order to use it's damage prevention ability
+               
+         for autoS in CardsAS.get(card.model,'').split('||'):
+            if re.search(r'trashCost', autoS) and re.search(re.escape(protectionType), autoS):
+               if not (re.search(r'trashCost-ifEmpty', autoS) and card.markers[mdict[protectionType]] > 0):     
+                  ModifyStatus('TrashMyself', targetPL.name, card, notification = 'Quick') # If the modulator -trashCost is there, the card trashes itself in order to use it's damage prevention ability
          if DMGdone == 0: break
    debugNotify("<<< findDMGProtection() by returning: {}".format(protectionFound), 3)
    return protectionFound


### PR DESCRIPTION
findDMGProtection() checks the entire card for trashCost, not
differentiating between different AutoScripts with different costs. I've
fixed that here by looping over AutoScripts rather than over cards when
preventing damage. I've also tidied up a bit of the boolean logic.

I've tested both activated and triggered abilities of Feedback Filter,
as well as Deus X and Plascrete Carapace to make sure I didn't
botch anything on the way. Caveat: I only tested with runner
self-inflicted damage (R-click > Runner Actions > Suffer 1 TYPE
Damage), though I don't expect this will be different for dealing
large quantities of damage (e.g. Neural Katana, Cerebral Overwriter).

Ref: https://github.com/db0/Android-Netrunner-OCTGN/issues/330
